### PR TITLE
Require Jenkins 2.346.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,8 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.509.4</version><!-- which version of Jenkins is this plugin built 
-			against? -->
+		<version>4.51</version>
+                <relativePath></relativePath>
 	</parent>
 	<name> Email Ext Recipients Column Plugin</name>
 	<groupId>org.jenkins-ci.plugins</groupId>
@@ -43,174 +43,30 @@
 		</developer>
 	</developers>
 	<scm>
-		<connection>
-			scm:git:ssh://github.com/jenkinsci/email-ext-recipients-column-plugin.git
-		</connection>
-		<developerConnection>
-			scm:git:ssh://git@github.com/jenkinsci/email-ext-recipients-column-plugin.git
-		</developerConnection>
-		<url> https://github.com/jenkinsci/email-ext-recipients-column-plugin</url>
+		<connection>scm:git:https://github.com/jenkinsci/email-ext-recipients-column-plugin.git</connection>
+		<developerConnection>scm:git:git@github.com:jenkinsci/email-ext-recipients-column-plugin.git</developerConnection>
+		<url>https://github.com/jenkinsci/email-ext-recipients-column-plugin</url>
 	</scm>
 	
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven-site-plugin.version>3.3 </maven-site-plugin.version>
-		<maven-surefire-plugin.version>2.16</maven-surefire-plugin.version>
-		<maven-surefire-report-plugin.version>${maven-surefire-plugin.version}</maven-surefire-report-plugin.version>
-		<maven-javadoc-plugin.version>2.9.1</maven-javadoc-plugin.version>
-		<maven-checkstyle-plugin.version>2.11</maven-checkstyle-plugin.version>
-		<findbugs-maven-plugin.version>2.5.2</findbugs-maven-plugin.version>
-		<cobertura-maven-plugin.version>2.6</cobertura-maven-plugin.version>
-		<maven-pmd-plugin.version>3.0.1</maven-pmd-plugin.version>
-		<maven-dependency-plugin.version>2.8</maven-dependency-plugin.version>
-		<maven-project-info-reports-plugin.version>2.7</maven-project-info-reports-plugin.version>
-		<maven-jxr-plugin.version>2.3</maven-jxr-plugin.version>
+                <jenkins.version>2.346.3</jenkins.version>
 	</properties>
 	
+        <dependencyManagement>
+                <dependencies>
+                        <dependency>
+                                <groupId>io.jenkins.tools.bom</groupId>
+                                <artifactId>bom-2.346.x</artifactId>
+                                <version>1723.vcb_9fee52c9fc</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                        </dependency>
+                </dependencies>
+        </dependencyManagement>
 	<dependencies>
         <dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>email-ext</artifactId>
-			<version>2.25</version>
 		</dependency>
 	</dependencies>
-	
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>cobertura-maven-plugin</artifactId>
-				<configuration>
-					<instrumentation>
-					</instrumentation>
-				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>instrument</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-site-plugin</artifactId>
-				<version>${maven-site-plugin.version}</version>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-dependency-plugin</artifactId>
-				<version>${maven-dependency-plugin.version}</version>
-				<executions>
-					<execution>
-						<id>jswidgets-plugin-analyze</id>
-						<phase>validate</phase>
-						<configuration>
-							<scriptableOutput>true</scriptableOutput>
-						</configuration>
-						<goals>
-							<goal>analyze-only</goal>
-							<goal>tree</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>${maven-surefire-plugin.version}</version>
-				<configuration>
-					<redirectTestOutputToFile>true</redirectTestOutputToFile>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
-	<reporting>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-project-info-reports-plugin</artifactId>
-				<version>${maven-project-info-reports-plugin.version}</version>
-				<configuration>
-					<dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-					<dependencyDetailsEnabled>false</dependencyDetailsEnabled>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jxr-plugin</artifactId>
-				<version>${maven-jxr-plugin.version}</version>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${maven-javadoc-plugin.version}</version>
-				<configuration>
-					<show>private</show>
-					<quiet>true</quiet>
-					<links>
-						<link>http://docs.oracle.com/javase/6/docs/api/</link>
-						<link>http://javadoc.jenkins-ci.org/</link>
-						<link>http://stapler.java.net/apidocs/</link>
-					</links>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>${maven-surefire-report-plugin.version}</version>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>${maven-checkstyle-plugin.version}</version>
-				<configuration>
-					<enableRulesSummary>false</enableRulesSummary>
-					<configLocation>${basedir}/src/conf/checkstyle-ruleset.xml
-					</configLocation>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-pmd-plugin</artifactId>
-				<version>${maven-pmd-plugin.version}</version>
-				<configuration>
-					<linkXRef>true</linkXRef>
-					<includeTests>true</includeTests>
-					<sourceEncoding>utf-8</sourceEncoding>
-					<minimumTokens>100</minimumTokens>
-					<targetJdk>1.5</targetJdk>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>${findbugs-maven-plugin.version}</version>
-				<configuration>
-					<xmlOutput>true</xmlOutput>
-					<threshold>Low</threshold>
-					<effort>Max</effort>
-					<debug>false</debug>
-					<relaxed>false</relaxed>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>cobertura-maven-plugin</artifactId>
-				<version>${cobertura-maven-plugin.version}</version>
-				<configuration>
-					<formats>
-						<format>xml</format>
-						<format>html</format>
-					</formats>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-dependency-plugin</artifactId>
-				<version>${maven-dependency-plugin.version}</version>
-			</plugin>
-		</plugins>
-	</reporting>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/emailextrecipientscolumn/EmailExtRecipientsColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/emailextrecipientscolumn/EmailExtRecipientsColumn.java
@@ -52,14 +52,13 @@ public final class EmailExtRecipientsColumn extends ListViewColumn {
         if (!(job instanceof AbstractProject<?, ?>)) {
             return "Not an AbstractProject";
         }
-        try {
-            AbstractProject<?, ?> project = (AbstractProject<?, ?>) job;
-            recipients = project.getPublishersList().get(
-                    ExtendedEmailPublisher.class).recipientList;
-        } catch (NullPointerException e) {
-            // values could not be retrieved
+        AbstractProject<?, ?> project = (AbstractProject<?, ?>) job;
+        if (project.getPublishersList() == null
+            || project.getPublishersList().get(ExtendedEmailPublisher.class) == null) {
             return "Disabled";
         }
+        recipients = project.getPublishersList().get(ExtendedEmailPublisher.class).recipientList;
+
         return recipients;
     }
 }

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,6 +1,7 @@
 <!--
   This view is used to render the installed plugins page.
 -->
+<?jelly escape-by-default='true'?>
 <div>
   This plugin is a sample to explain how to write a Jenkins plugin.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/emailextrecipientscolumn/EmailExtRecipientsColumn/column.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/emailextrecipientscolumn/EmailExtRecipientsColumn/column.jelly
@@ -1,4 +1,3 @@
-
 <?jelly escape-by-default="true"?>
 <j:jelly xmlns:j="jelly:core">
 	<j:set var="recipients" value="${it.getRecipients(job)}"/>


### PR DESCRIPTION
## Require Jenkins 2.346.3 or newer

- Prevent null pointer exception, don't catch it
- Require Jenkins 2.346.3
- Escape jelly contents by default
- Escape jelly contents by default

Modernize the plugin development environment by updating the parent pom, requiring a modern Jenkin version, and removing many of the items that are no longer required in the pom file.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
