### PR TITLE
Require Jenkins 2.479.1 and Jakarta EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,26 +17,6 @@
   <name>Email Ext Recipients Column Plugin</name>
   <url>https://github.com/${gitHubRepo}</url>
 
-  <developers>
-    <developer>
-      <id>markewaite</id>
-      <name>Mark Waite</name>
-      <email>mark.earl.waite@gmail.com</email>
-    </developer>
-    <!-- <developer> -->
-    <!--   <id>stefanbrausch</id> -->
-    <!--   <name>Stefan Brausch</name> -->
-    <!--   <email>stefanbrausch@protonmail.ch</email> -->
-    <!--   <role>emeritus</role> -->
-    <!-- </developer> -->
-    <!-- <developer> -->
-    <!--   <id>boev</id> -->
-    <!--   <name>Yordan Boev</name> -->
-    <!--   <email>iordan.boev@gmail.com</email> -->
-    <!--   <role>emeritus</role> -->
-    <!-- </developer> -->
-  </developers>
-
   <scm>
     <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.6</version>
     <relativePath></relativePath>
   </parent>
 
@@ -27,8 +27,8 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/email-ext-recipients-column-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.452</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
   </properties>
 
   <dependencyManagement>
@@ -36,7 +36,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3944.v1a_e4f8b_452db_</version>
+        <version>4051.v78dce3ce8b_d6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/org/jenkinsci/plugins/emailextrecipientscolumn/EmailExtRecipientsColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/emailextrecipientscolumn/EmailExtRecipientsColumn.java
@@ -10,7 +10,7 @@ import hudson.views.ListViewColumnDescriptor;
 import hudson.views.ListViewColumn;
 import net.sf.json.JSONObject;
 
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 public final class EmailExtRecipientsColumn extends ListViewColumn {
 
@@ -25,7 +25,7 @@ public final class EmailExtRecipientsColumn extends ListViewColumn {
         }
 
         @Override
-        public ListViewColumn newInstance(final StaplerRequest request,
+        public ListViewColumn newInstance(final StaplerRequest2 request,
                 final JSONObject formData) throws FormException {
             return new EmailExtRecipientsColumn();
         }


### PR DESCRIPTION
## Require Jenkins 2.479.1 and Jakarta EE 9

Require Jenkins 2.479.1 and Jakarta EE 9 so that we can eventually reduce the amount of code in the compatibility layer for Spring Security 5, Java EE 8, and Eclipse Jetty 10.

- Remove outdated, unused developer section

### Testing done

Confirmed that automated tests pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
